### PR TITLE
Update Windows build script for USD 25.08 and add CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,6 +3,7 @@ name: Windows Build
 on:
   push:
     branches: [develop, main]
+    tags: ["v*"]
   pull_request:
     branches: [develop, main]
   workflow_dispatch:
@@ -197,3 +198,62 @@ jobs:
           }
           Write-Host "Build successful: $exe"
           Write-Host "Size: $([math]::Round((Get-Item $exe).Length / 1MB, 1)) MB"
+
+      - name: Package portable bundle
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        run: |
+          $usdDir = "${{ github.workspace }}/build/usd"
+
+          # Use cmake --install to create a self-contained portable bundle
+          cmake --install build/cmake --prefix build/install --config ${{ env.BUILD_CONFIG }}
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+          # Verify the installed exe works
+          if (-not (Test-Path build/install/bin/usdtweak.exe)) {
+              Write-Error "Portable bundle missing usdtweak.exe"
+              exit 1
+          }
+
+          # Copy USD plugin/resource directories needed at runtime
+          # (cmake --install already handles DLLs, plugins, and python libs)
+
+          # Add a launch script to the bundle
+          @'
+          @echo off
+          set USDROOT=%~dp0
+          set PATH=%USDROOT%bin;%PATH%
+          set PYTHONPATH=%USDROOT%bin\python;%PYTHONPATH%
+          start "" "%USDROOT%bin\usdtweak.exe" %*
+          '@ | Set-Content "build/install/usdtweak.bat" -Encoding ASCII
+
+          # Add the LICENSE
+          Copy-Item LICENSE build/install/LICENSE.txt
+
+          # Create the zip
+          $tag = "${{ github.ref_name }}"
+          $zipName = "usdtweak-${tag}-windows-x64-usd${{ env.USD_VERSION }}.zip"
+          Compress-Archive -Path build/install/* -DestinationPath "build/$zipName"
+          Write-Host "Package created: $zipName"
+          Write-Host "Size: $([math]::Round((Get-Item "build/$zipName").Length / 1MB, 1)) MB"
+
+          # Export for the release step
+          echo "PACKAGE_NAME=$zipName" >> $env:GITHUB_ENV
+          echo "PACKAGE_PATH=build/$zipName" >> $env:GITHUB_ENV
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.PACKAGE_PATH }}
+          generate_release_notes: true
+          body: |
+            ## Windows portable build
+
+            **${{ env.PACKAGE_NAME }}** — self-contained bundle, no installation needed.
+
+            Extract the zip, run `usdtweak.bat`, or run `bin\usdtweak.exe` directly.
+
+            Built with:
+            - USD ${{ env.USD_VERSION }} (NVIDIA pre-built, Python 3.12)
+            - Visual Studio 2022 (${{ env.BUILD_CONFIG }})

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,198 @@
+name: Windows Build
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+env:
+  USD_VERSION: "25.08"
+  USD_URL: "https://developer.nvidia.com/downloads/usd/usd_binaries/25.08/usd.py312.windows-x86_64.usdview.release-v25.08.71e038c1.zip"
+  BUILD_CONFIG: RelWithDebInfo
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache USD ${{ env.USD_VERSION }}
+        id: cache-usd
+        uses: actions/cache@v4
+        with:
+          path: build/usd
+          key: usd-windows-${{ env.USD_VERSION }}
+
+      - name: Download USD ${{ env.USD_VERSION }}
+        if: steps.cache-usd.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path build/usd | Out-Null
+          Write-Host "Downloading USD ${{ env.USD_VERSION }} from NVIDIA..."
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "${{ env.USD_URL }}" -OutFile build/usd.zip
+          $ProgressPreference = 'Continue'
+
+          # Verify download
+          $size = (Get-Item build/usd.zip).Length
+          if ($size -lt 100000000) {
+              Write-Error "Download appears truncated ($size bytes)"
+              exit 1
+          }
+          Write-Host "Downloaded $([math]::Round($size / 1MB)) MB"
+
+          Write-Host "Extracting..."
+          Expand-Archive -Path build/usd.zip -DestinationPath build/usd -Force
+          Remove-Item build/usd.zip -Force
+
+          if (-not (Test-Path build/usd/pxrConfig.cmake)) {
+              Write-Error "Extraction failed - pxrConfig.cmake not found"
+              exit 1
+          }
+          Write-Host "USD ${{ env.USD_VERSION }} ready"
+
+      - name: Generate CMake configs for USD dependencies
+        if: steps.cache-usd.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          # The NVIDIA USD package ships TBB, OpenSubdiv, and Imath libraries
+          # but omits their CMake config files. pxrConfig.cmake needs them.
+
+          $usdDir = "build/usd"
+
+          # --- TBB ---
+          $dir = "$usdDir/lib/cmake/TBB"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          @'
+          get_filename_component(_TBB_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+          if(NOT TARGET TBB::tbb)
+              add_library(TBB::tbb SHARED IMPORTED)
+              set_target_properties(TBB::tbb PROPERTIES
+                  IMPORTED_IMPLIB "${_TBB_ROOT}/lib/tbb.lib"
+                  IMPORTED_LOCATION "${_TBB_ROOT}/bin/tbb.dll"
+                  INTERFACE_INCLUDE_DIRECTORIES "${_TBB_ROOT}/include"
+              )
+          endif()
+          set(TBB_FOUND TRUE)
+          set(TBB_VERSION "2020.3")
+          '@ | Set-Content "$dir/TBBConfig.cmake" -Encoding UTF8
+          @'
+          set(PACKAGE_VERSION "2020.3")
+          if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+              set(PACKAGE_VERSION_COMPATIBLE FALSE)
+          else()
+              set(PACKAGE_VERSION_COMPATIBLE TRUE)
+              if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+                  set(PACKAGE_VERSION_EXACT TRUE)
+              endif()
+          endif()
+          '@ | Set-Content "$dir/TBBConfigVersion.cmake" -Encoding UTF8
+
+          # --- OpenSubdiv ---
+          $dir = "$usdDir/lib/cmake/OpenSubdiv"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          @'
+          get_filename_component(_OSD_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+          if(NOT TARGET opensubdiv::opensubdiv)
+              add_library(opensubdiv::opensubdiv INTERFACE IMPORTED)
+              add_library(opensubdiv::osdCPU STATIC IMPORTED)
+              set_target_properties(opensubdiv::osdCPU PROPERTIES
+                  IMPORTED_LOCATION "${_OSD_ROOT}/lib/osdCPU.lib"
+              )
+              add_library(opensubdiv::osdGPU STATIC IMPORTED)
+              set_target_properties(opensubdiv::osdGPU PROPERTIES
+                  IMPORTED_LOCATION "${_OSD_ROOT}/lib/osdGPU.lib"
+              )
+              set_target_properties(opensubdiv::opensubdiv PROPERTIES
+                  INTERFACE_LINK_LIBRARIES "opensubdiv::osdCPU;opensubdiv::osdGPU"
+                  INTERFACE_INCLUDE_DIRECTORIES "${_OSD_ROOT}/include"
+              )
+          endif()
+          set(OpenSubdiv_FOUND TRUE)
+          set(OpenSubdiv_VERSION "3.6.0")
+          '@ | Set-Content "$dir/OpenSubdivConfig.cmake" -Encoding UTF8
+          @'
+          set(PACKAGE_VERSION "3.6.0")
+          if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+              set(PACKAGE_VERSION_COMPATIBLE FALSE)
+          else()
+              set(PACKAGE_VERSION_COMPATIBLE TRUE)
+              if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+                  set(PACKAGE_VERSION_EXACT TRUE)
+              endif()
+          endif()
+          '@ | Set-Content "$dir/OpenSubdivConfigVersion.cmake" -Encoding UTF8
+
+          # --- Imath ---
+          $dir = "$usdDir/lib/cmake/Imath"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          @'
+          get_filename_component(_IMATH_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+          if(NOT TARGET Imath::Imath)
+              add_library(Imath::Imath SHARED IMPORTED)
+              set_target_properties(Imath::Imath PROPERTIES
+                  IMPORTED_IMPLIB "${_IMATH_ROOT}/lib/Imath-3_1.lib"
+                  IMPORTED_LOCATION "${_IMATH_ROOT}/bin/Imath-3_1.dll"
+                  INTERFACE_INCLUDE_DIRECTORIES "${_IMATH_ROOT}/include;${_IMATH_ROOT}/include/Imath"
+              )
+          endif()
+          if(NOT TARGET Imath::ImathConfig)
+              add_library(Imath::ImathConfig INTERFACE IMPORTED)
+              set_target_properties(Imath::ImathConfig PROPERTIES
+                  INTERFACE_INCLUDE_DIRECTORIES "${_IMATH_ROOT}/include;${_IMATH_ROOT}/include/Imath"
+              )
+          endif()
+          set(Imath_FOUND TRUE)
+          set(Imath_VERSION "3.1.12")
+          '@ | Set-Content "$dir/ImathConfig.cmake" -Encoding UTF8
+          @'
+          set(PACKAGE_VERSION "3.1.12")
+          if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+              set(PACKAGE_VERSION_COMPATIBLE FALSE)
+          else()
+              set(PACKAGE_VERSION_COMPATIBLE TRUE)
+              if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+                  set(PACKAGE_VERSION_EXACT TRUE)
+              endif()
+          endif()
+          '@ | Set-Content "$dir/ImathConfigVersion.cmake" -Encoding UTF8
+
+          Write-Host "CMake configs generated for TBB, OpenSubdiv, and Imath"
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          $usdDir = "${{ github.workspace }}/build/usd"
+          cmake `
+              -G "Visual Studio 17 2022" `
+              -A x64 `
+              -B build/cmake `
+              "-DCMAKE_PREFIX_PATH=$usdDir/lib/cmake" `
+              "-Dpxr_DIR=$usdDir" `
+              "-DMaterialX_DIR=$usdDir/lib/cmake/MaterialX" `
+              "-DImath_DIR=$usdDir/lib/cmake/Imath" `
+              "-DPython3_EXECUTABLE=$usdDir/python/python.exe" `
+              "-DPython3_LIBRARY=$usdDir/python/libs/python312.lib" `
+              "-DPython3_INCLUDE_DIR=$usdDir/python/include" `
+              "-DPython3_VERSION=3.12"
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Build
+        shell: pwsh
+        run: |
+          cmake --build build/cmake --config ${{ env.BUILD_CONFIG }} --parallel
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Verify executable
+        shell: pwsh
+        run: |
+          $exe = "build/cmake/${{ env.BUILD_CONFIG }}/usdtweak.exe"
+          if (-not (Test-Path $exe)) {
+              Write-Error "usdtweak.exe not found at $exe"
+              exit 1
+          }
+          Write-Host "Build successful: $exe"
+          Write-Host "Size: $([math]::Round((Get-Item $exe).Length / 1MB, 1)) MB"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  workflow_dispatch:
 
 env:
   USD_VERSION: "25.08"

--- a/windows-build.ps1
+++ b/windows-build.ps1
@@ -106,12 +106,28 @@ try {
     $pythonLibVersion = "312"
     $usdUrl = "https://developer.nvidia.com/downloads/usd/usd_binaries/25.08/usd.py312.windows-x86_64.usdview.release-v25.08.71e038c1.zip"
 
-    # Check if USD directory exists and has the expected version
+    # Check if USD directory exists with the correct version
     $usdPresent = $false
     if (Test-Path $usdDir) {
-        if (Test-Path (Join-Path $usdDir "pxrConfig.cmake")) {
-            Write-Host "`nFound existing USD installation in build/usd" -ForegroundColor Green
-            $usdPresent = $true
+        $pxrConfig = Join-Path $usdDir "pxrConfig.cmake"
+        $pythonLib = Join-Path $usdDir "python\libs\python${pythonLibVersion}.lib"
+        if ((Test-Path $pxrConfig) -and (Test-Path $pythonLib)) {
+            # Verify the USD version matches what we expect
+            $pxrContent = Get-Content $pxrConfig -Raw
+            if ($pxrContent -match 'set\(PXR_VERSION\s+"(\d+)"\)') {
+                $installedVersion = $Matches[1]
+                $expectedVersion = $usdVersion -replace '\.', ''  # "25.08" -> "2508"
+                if ($installedVersion -eq $expectedVersion) {
+                    Write-Host "`nFound existing USD $usdVersion installation in build/usd" -ForegroundColor Green
+                    $usdPresent = $true
+                } else {
+                    Write-Host "`nExisting USD is version $installedVersion but $expectedVersion is required, re-downloading..." -ForegroundColor Yellow
+                    Remove-Item -Path $usdDir -Recurse -Force
+                }
+            } else {
+                Write-Host "`nCould not determine USD version, re-downloading..." -ForegroundColor Yellow
+                Remove-Item -Path $usdDir -Recurse -Force
+            }
         } else {
             Write-Host "`nUSD directory exists but appears incomplete, re-downloading..." -ForegroundColor Yellow
             Remove-Item -Path $usdDir -Recurse -Force

--- a/windows-build.ps1
+++ b/windows-build.ps1
@@ -1,33 +1,97 @@
-# Ensure the window stays open
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
 Write-Host "Starting build script..." -ForegroundColor Cyan
 Start-Sleep -Seconds 1
 
 try {
-    # Ensure we stop on any errors
     $ErrorActionPreference = "Stop"
 
     Write-Host "USDTweak Automated Build Script" -ForegroundColor Cyan
     Write-Host "================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Prerequisites:" -ForegroundColor White
+    Write-Host "  - Git          https://git-scm.com/download/win" -ForegroundColor White
+    Write-Host "  - CMake 3.14+  https://cmake.org/download/" -ForegroundColor White
+    Write-Host "  - Visual Studio 2022 with C++ desktop workload" -ForegroundColor White
+    Write-Host "  - ~3 GB free disk space" -ForegroundColor White
+    Write-Host ""
 
     # Function to check if a command exists
     function Test-Command($cmdname) {
         return [bool](Get-Command -Name $cmdname -ErrorAction SilentlyContinue)
     }
 
-    # Check prerequisites
-    $prerequisites = @{
-        "git" = "Git is required. Download from: https://git-scm.com/download/win"
-        "cmake" = "CMake is required. Download from: https://cmake.org/download/"
+    # Check git
+    if (-not (Test-Command "git")) {
+        Write-Host "Error: Git is not installed or not in PATH." -ForegroundColor Red
+        Write-Host "Download from: https://git-scm.com/download/win" -ForegroundColor Yellow
+        pause
+        exit 1
     }
 
-    foreach ($cmd in $prerequisites.Keys) {
-        if (-not (Test-Command $cmd)) {
-            Write-Host "Error: $($prerequisites[$cmd])" -ForegroundColor Red
+    # Check cmake
+    if (-not (Test-Command "cmake")) {
+        Write-Host "Error: CMake is not installed or not in PATH." -ForegroundColor Red
+        Write-Host "Download from: https://cmake.org/download/" -ForegroundColor Yellow
+        pause
+        exit 1
+    }
+
+    # Check cmake version
+    $cmakeVersionOutput = & cmake --version 2>&1 | Select-Object -First 1
+    if ($cmakeVersionOutput -match "(\d+\.\d+)") {
+        $cmakeVer = [version]$Matches[1]
+        if ($cmakeVer -lt [version]"3.14") {
+            Write-Host "Error: CMake 3.14 or higher is required (found $cmakeVersionOutput)." -ForegroundColor Red
+            Write-Host "Download from: https://cmake.org/download/" -ForegroundColor Yellow
             pause
             exit 1
         }
+        Write-Host "Found CMake $($Matches[1])" -ForegroundColor Green
     }
+
+    # Check Visual Studio 2022 with C++ workload
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path $vswhere)) {
+        Write-Host "Error: Visual Studio Installer not found. Visual Studio 2022 is required." -ForegroundColor Red
+        Write-Host "Download from: https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
+        pause
+        exit 1
+    }
+
+    $vsInstall = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+    if (-not $vsInstall) {
+        $vsAny = & $vswhere -latest -property installationPath 2>$null
+        if ($vsAny) {
+            Write-Host "Error: Visual Studio found at '$vsAny' but the C++ desktop development workload is not installed." -ForegroundColor Red
+            Write-Host "Open Visual Studio Installer and add 'Desktop development with C++'." -ForegroundColor Yellow
+        } else {
+            Write-Host "Error: Visual Studio 2022 is not installed." -ForegroundColor Red
+            Write-Host "Download from: https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
+        }
+        pause
+        exit 1
+    }
+
+    $vsVersion = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion 2>$null
+    if ($vsVersion -ne "2022") {
+        Write-Host "Error: Visual Studio 2022 is required (found VS $vsVersion)." -ForegroundColor Red
+        Write-Host "Download from: https://visualstudio.microsoft.com/downloads/" -ForegroundColor Yellow
+        pause
+        exit 1
+    }
+    Write-Host "Found Visual Studio 2022 with C++ workload" -ForegroundColor Green
+
+    # Check disk space (~3 GB needed)
+    $scriptDrive = (Resolve-Path $PSScriptRoot).Drive
+    $freeGB = [math]::Round((Get-PSDrive $scriptDrive.Name).Free / 1GB, 1)
+    if ($freeGB -lt 3) {
+        Write-Host "Error: Insufficient disk space. Need ~3 GB free, only $freeGB GB available on drive $($scriptDrive.Name):." -ForegroundColor Red
+        pause
+        exit 1
+    }
+    Write-Host "Disk space: $freeGB GB free" -ForegroundColor Green
+
+    Write-Host "`nAll prerequisites satisfied." -ForegroundColor Green
 
     # Create build directory
     $buildDir = Join-Path $PSScriptRoot "build"
@@ -36,43 +100,31 @@ try {
     # Define USD directory path
     $usdDir = Join-Path $buildDir "usd"
 
-    # Check if USD directory exists first
-    $usdPresent = Test-Path $usdDir
-    if ($usdPresent) {
-        # Only verify files if directory exists
-        $usdValidationPaths = @(
-            (Join-Path $usdDir "pxrConfig.cmake"),  # Corrected path for pxrConfig.cmake
-            (Join-Path $usdDir "lib\cmake\MaterialX\MaterialXConfig.cmake"),  # Corrected path for MaterialXConfig.cmake
-            (Join-Path $usdDir "python\python.exe")
-        )
+    # USD 25.08 with Python 3.12 from NVIDIA
+    $usdVersion = "25.08"
+    $pythonVersion = "3.12"
+    $pythonLibVersion = "312"
+    $usdUrl = "https://developer.nvidia.com/downloads/usd/usd_binaries/25.08/usd.py312.windows-x86_64.usdview.release-v25.08.71e038c1.zip"
 
-        $missingFiles = @()
-        foreach ($path in $usdValidationPaths) {
-            if (-not (Test-Path $path)) {
-                $missingFiles += $path
-            }
-        }
-
-        if ($missingFiles.Count -gt 0) {
-            Write-Host "Warning: USD directory exists but missing required files:" -ForegroundColor Yellow
-            foreach ($file in $missingFiles) {
-                Write-Host "  - $file" -ForegroundColor Yellow
-            }
-            # Removed the deletion of the USD directory
-            # $usdPresent = $false
-            # Remove-Item -Path $usdDir -Recurse -Force
+    # Check if USD directory exists and has the expected version
+    $usdPresent = $false
+    if (Test-Path $usdDir) {
+        if (Test-Path (Join-Path $usdDir "pxrConfig.cmake")) {
+            Write-Host "`nFound existing USD installation in build/usd" -ForegroundColor Green
+            $usdPresent = $true
+        } else {
+            Write-Host "`nUSD directory exists but appears incomplete, re-downloading..." -ForegroundColor Yellow
+            Remove-Item -Path $usdDir -Recurse -Force
         }
     }
 
     if (-not $usdPresent) {
-        # Create USD directory only if we need to download
         New-Item -ItemType Directory -Force -Path $usdDir | Out-Null
-        
-        # Download USD from NVIDIA
-        $usdUrl = "https://developer.nvidia.com/downloads/USD/usd_binaries/24.11/usd.py311.windows-x86_64.usdview.release-0.24.11-4d81dd85.zip"
+
         $usdZip = Join-Path $buildDir "usd.zip"
 
-        Write-Host "`nDownloading USD from NVIDIA..." -ForegroundColor Yellow
+        Write-Host "`nDownloading USD $usdVersion from NVIDIA (~464 MB)..." -ForegroundColor Yellow
+        Write-Host "This may take several minutes depending on your connection." -ForegroundColor DarkGray
         try {
             $ProgressPreference = 'SilentlyContinue'
             Invoke-WebRequest -Uri $usdUrl -OutFile $usdZip
@@ -84,7 +136,15 @@ try {
             exit 1
         }
 
-        # Extract USD - Try to use 7-Zip if available
+        # Verify the download isn't empty or truncated
+        if (-not (Test-Path $usdZip) -or (Get-Item $usdZip).Length -lt 100000000) {
+            Write-Host "Error: Downloaded file appears to be incomplete or corrupted. Please try again." -ForegroundColor Red
+            if (Test-Path $usdZip) { Remove-Item -Path $usdZip -Force }
+            pause
+            exit 1
+        }
+
+        # Extract USD
         Write-Host "Extracting USD..." -ForegroundColor Yellow
         $sevenZip = "${env:ProgramFiles}\7-Zip\7z.exe"
         if (Test-Path $sevenZip) {
@@ -95,32 +155,155 @@ try {
                 Expand-Archive -Path $usdZip -DestinationPath $usdDir -Force
             }
         } else {
-            Write-Host "7-Zip not found, using PowerShell extraction..." -ForegroundColor Yellow
+            Write-Host "7-Zip not found, using PowerShell extraction (this may be slow for large archives)..." -ForegroundColor Yellow
             Expand-Archive -Path $usdZip -DestinationPath $usdDir -Force
         }
 
         # Remove the zip file after extraction
-        Remove-Item -Path $usdZip -Force
-
-        # Diagnostic: Check what's in the extracted directory
-        Write-Host "Checking USD directory structure..." -ForegroundColor Yellow
-        Write-Host "Contents of ${usdDir}:" -ForegroundColor Yellow
-        Get-ChildItem -Path ${usdDir} | ForEach-Object {
-            Write-Host "  - $($_.Name)"
+        if (Test-Path $usdZip) {
+            Remove-Item -Path $usdZip -Force
         }
 
-        # Search for pxrConfig.cmake
-        Write-Host "`nSearching for pxrConfig.cmake..." -ForegroundColor Yellow
-        $pxrConfigFiles = Get-ChildItem -Path $usdDir -Recurse -Filter "pxrConfig.cmake"
-        if ($pxrConfigFiles) {
-            foreach ($file in $pxrConfigFiles) {
-                Write-Host "  Found at: $($file.FullName)"
-            }
-        } else {
-            Write-Host "  No pxrConfig.cmake found!"
+        # Verify extraction succeeded
+        if (-not (Test-Path (Join-Path $usdDir "pxrConfig.cmake"))) {
+            Write-Host "Error: USD extraction failed - pxrConfig.cmake not found in build/usd." -ForegroundColor Red
+            Write-Host "Try deleting the build/usd directory and running this script again." -ForegroundColor Yellow
+            pause
+            exit 1
         }
+
+        Write-Host "USD $usdVersion extracted successfully" -ForegroundColor Green
     } else {
-        Write-Host "`nUsing existing USD installation in build/usd" -ForegroundColor Green
+        Write-Host "Using existing USD installation in build/usd" -ForegroundColor Green
+    }
+
+    # ----------------------------------------------------------------
+    # The NVIDIA USD package ships TBB, OpenSubdiv, and Imath libraries
+    # but does not include CMake config files for them. The pxrConfig.cmake
+    # expects to find these via find_dependency(), so we create minimal
+    # config files that define the required imported targets.
+    # ----------------------------------------------------------------
+
+    # Create TBB CMake config
+    $tbbCmakeDir = Join-Path $usdDir "lib\cmake\TBB"
+    if (-not (Test-Path (Join-Path $tbbCmakeDir "TBBConfig.cmake"))) {
+        Write-Host "Creating TBB CMake config..." -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $tbbCmakeDir | Out-Null
+
+        @'
+get_filename_component(_TBB_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+if(NOT TARGET TBB::tbb)
+    add_library(TBB::tbb SHARED IMPORTED)
+    set_target_properties(TBB::tbb PROPERTIES
+        IMPORTED_IMPLIB "${_TBB_ROOT}/lib/tbb.lib"
+        IMPORTED_LOCATION "${_TBB_ROOT}/bin/tbb.dll"
+        INTERFACE_INCLUDE_DIRECTORIES "${_TBB_ROOT}/include"
+    )
+endif()
+
+set(TBB_FOUND TRUE)
+set(TBB_VERSION "2020.3")
+'@ | Set-Content (Join-Path $tbbCmakeDir "TBBConfig.cmake") -Encoding UTF8
+
+        @'
+set(PACKAGE_VERSION "2020.3")
+if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()
+'@ | Set-Content (Join-Path $tbbCmakeDir "TBBConfigVersion.cmake") -Encoding UTF8
+    }
+
+    # Create OpenSubdiv CMake config
+    $osdCmakeDir = Join-Path $usdDir "lib\cmake\OpenSubdiv"
+    if (-not (Test-Path (Join-Path $osdCmakeDir "OpenSubdivConfig.cmake"))) {
+        Write-Host "Creating OpenSubdiv CMake config..." -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $osdCmakeDir | Out-Null
+
+        @'
+get_filename_component(_OSD_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+if(NOT TARGET opensubdiv::opensubdiv)
+    add_library(opensubdiv::opensubdiv INTERFACE IMPORTED)
+
+    add_library(opensubdiv::osdCPU STATIC IMPORTED)
+    set_target_properties(opensubdiv::osdCPU PROPERTIES
+        IMPORTED_LOCATION "${_OSD_ROOT}/lib/osdCPU.lib"
+    )
+
+    add_library(opensubdiv::osdGPU STATIC IMPORTED)
+    set_target_properties(opensubdiv::osdGPU PROPERTIES
+        IMPORTED_LOCATION "${_OSD_ROOT}/lib/osdGPU.lib"
+    )
+
+    set_target_properties(opensubdiv::opensubdiv PROPERTIES
+        INTERFACE_LINK_LIBRARIES "opensubdiv::osdCPU;opensubdiv::osdGPU"
+        INTERFACE_INCLUDE_DIRECTORIES "${_OSD_ROOT}/include"
+    )
+endif()
+
+set(OpenSubdiv_FOUND TRUE)
+set(OpenSubdiv_VERSION "3.6.0")
+'@ | Set-Content (Join-Path $osdCmakeDir "OpenSubdivConfig.cmake") -Encoding UTF8
+
+        @'
+set(PACKAGE_VERSION "3.6.0")
+if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()
+'@ | Set-Content (Join-Path $osdCmakeDir "OpenSubdivConfigVersion.cmake") -Encoding UTF8
+    }
+
+    # Create Imath CMake config
+    $imathCmakeDir = Join-Path $usdDir "lib\cmake\Imath"
+    if (-not (Test-Path (Join-Path $imathCmakeDir "ImathConfig.cmake"))) {
+        Write-Host "Creating Imath CMake config..." -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $imathCmakeDir | Out-Null
+
+        @'
+get_filename_component(_IMATH_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+if(NOT TARGET Imath::Imath)
+    add_library(Imath::Imath SHARED IMPORTED)
+    set_target_properties(Imath::Imath PROPERTIES
+        IMPORTED_IMPLIB "${_IMATH_ROOT}/lib/Imath-3_1.lib"
+        IMPORTED_LOCATION "${_IMATH_ROOT}/bin/Imath-3_1.dll"
+        INTERFACE_INCLUDE_DIRECTORIES "${_IMATH_ROOT}/include;${_IMATH_ROOT}/include/Imath"
+    )
+endif()
+
+if(NOT TARGET Imath::ImathConfig)
+    add_library(Imath::ImathConfig INTERFACE IMPORTED)
+    set_target_properties(Imath::ImathConfig PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_IMATH_ROOT}/include;${_IMATH_ROOT}/include/Imath"
+    )
+endif()
+
+set(Imath_FOUND TRUE)
+set(Imath_VERSION "3.1.12")
+'@ | Set-Content (Join-Path $imathCmakeDir "ImathConfig.cmake") -Encoding UTF8
+
+        @'
+set(PACKAGE_VERSION "3.1.12")
+if("${PACKAGE_FIND_VERSION}" VERSION_GREATER "${PACKAGE_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "${PACKAGE_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()
+'@ | Set-Content (Join-Path $imathCmakeDir "ImathConfigVersion.cmake") -Encoding UTF8
     }
 
     # Move to build directory
@@ -128,49 +311,31 @@ try {
 
     # Configure with CMake
     Write-Host "`nConfiguring with CMake..." -ForegroundColor Yellow
-    $cmakeArgs = @(
-        "-G`"Visual Studio 17 2022`"",
-        "-A", "x64",
-        "-Dpxr_DIR=`"$usdDir`"",
-        "-DMaterialX_DIR=`"$usdDir\lib\cmake\MaterialX`"",
-        "-DPython3_EXECUTABLE=`"$usdDir\python\python.exe`"",
-        "-DPython3_LIBRARY=`"$usdDir\python\libs\python311.lib`"",
-        "-DPython3_INCLUDE_DIR=`"$usdDir\python\include`"",
-        "-DPython3_VERSION=`"3.11`"",
-        "-DImath_DIR=`"$usdDir\lib\cmake\Imath`"",
-        ".."
-    )
-
-    $cmakeProcess = Start-Process cmake -ArgumentList ($cmakeArgs -join ' ') -NoNewWindow -Wait -PassThru
-    if ($cmakeProcess.ExitCode -ne 0) {
-        Write-Host "Error: CMake configuration failed" -ForegroundColor Red
+    & cmake `
+        -G "Visual Studio 17 2022" `
+        -A x64 `
+        "-DCMAKE_PREFIX_PATH=$usdDir\lib\cmake" `
+        "-Dpxr_DIR=$usdDir" `
+        "-DMaterialX_DIR=$usdDir\lib\cmake\MaterialX" `
+        "-DImath_DIR=$usdDir\lib\cmake\Imath" `
+        "-DPython3_EXECUTABLE=$usdDir\python\python.exe" `
+        "-DPython3_LIBRARY=$usdDir\python\libs\python${pythonLibVersion}.lib" `
+        "-DPython3_INCLUDE_DIR=$usdDir\python\include" `
+        "-DPython3_VERSION=$pythonVersion" `
+        ..
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: CMake configuration failed." -ForegroundColor Red
+        Write-Host "Check the output above for details." -ForegroundColor Yellow
         pause
         exit 1
-    }
-
-    # Fix the osdGPU.lib and osdCPU.lib issue in pxrTargets.cmake
-    $pxrTargetsPath = Join-Path $usdDir "cmake\pxrTargets.cmake"
-    if (Test-Path $pxrTargetsPath) {
-        $content = Get-Content $pxrTargetsPath
-        $content = $content -replace '\$\{_IMPORT_PREFIX\}/lib/osdGPU\.lib;', ''
-        $content = $content -replace '\$\{_IMPORT_PREFIX\}/lib/osdCPU\.lib;', ''
-        Set-Content $pxrTargetsPath $content
     }
 
     # Build the project
     Write-Host "`nBuilding project..." -ForegroundColor Yellow
-    $buildProcess = Start-Process cmake -ArgumentList "--build", ".", "--config", "RelWithDebInfo", "--parallel" -NoNewWindow -Wait -PassThru
-    if ($buildProcess.ExitCode -ne 0) {
-        Write-Host "Error: Build failed" -ForegroundColor Red
-        pause
-        exit 1
-    }
-
-    # Install
-    Write-Host "`nInstalling..." -ForegroundColor Yellow
-    $installProcess = Start-Process cmake -ArgumentList "--install", ".", "--prefix", "./install", "--config", "RelWithDebInfo" -NoNewWindow -Wait -PassThru
-    if ($installProcess.ExitCode -ne 0) {
-        Write-Host "Error: Installation failed" -ForegroundColor Red
+    & cmake --build . --config RelWithDebInfo --parallel
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Build failed." -ForegroundColor Red
+        Write-Host "Check the compiler output above for details." -ForegroundColor Yellow
         pause
         exit 1
     }
@@ -178,8 +343,18 @@ try {
     # Return to original directory
     Pop-Location
 
+    # Verify the executable was produced
+    $exePath = Join-Path $buildDir "RelWithDebInfo\usdtweak.exe"
+    if (-not (Test-Path $exePath)) {
+        Write-Host "Error: Build reported success but usdtweak.exe was not found at:" -ForegroundColor Red
+        Write-Host "  $exePath" -ForegroundColor Yellow
+        pause
+        exit 1
+    }
+
     Write-Host "`nBuild completed successfully!" -ForegroundColor Green
-    Write-Host "The built files can be found in: $buildDir\install" -ForegroundColor Green
+    Write-Host "Executable: $exePath" -ForegroundColor Green
+    Write-Host "Run usdtweak with: .\windows-start.bat" -ForegroundColor Green
 } catch {
     Write-Host "`nError occurred:" -ForegroundColor Red
     Write-Host $_.Exception.Message -ForegroundColor Red
@@ -188,12 +363,10 @@ try {
     pause
     exit 1
 } finally {
-    # Make sure we're back in the original directory
     if ($buildDir -and (Get-Location).Path -eq $buildDir) {
         Pop-Location
     }
 }
 
-# Move pause outside of try-catch so it always executes
 Write-Host "`nPress any key to exit..." -ForegroundColor Cyan
-pause 
+pause

--- a/windows-start.bat
+++ b/windows-start.bat
@@ -2,11 +2,8 @@
 REM Set the USDROOT environment variable to the relative path
 set USDROOT=.\build\usd
 
-REM Set the PYTHON_DIR to the Python directory in the USD build
-set PYTHON_DIR=%USDROOT%\python
-
 REM Update the PATH variable to include USD binaries, libraries, and Python
-set PATH=%USDROOT%\bin;%USDROOT%\lib;%PYTHON_DIR%;%PYTHON_DIR%\Scripts;%PATH%
+set PATH=%USDROOT%\bin;%USDROOT%\lib;%USDROOT%\python;%USDROOT%\python\Scripts;%PATH%
 
 REM Set the PYTHONPATH to include the USD Python libraries
 set PYTHONPATH=%USDROOT%\lib\python;%PYTHONPATH%


### PR DESCRIPTION
## Summary
- Upgrade **windows-build.ps1** from USD 24.11 (Python 3.11) to **USD 25.08** (Python 3.12) using NVIDIA pre-built binaries
- Generate missing CMake config files for **TBB**, **OpenSubdiv**, and **Imath** that the NVIDIA package ships without — replaces the old `osdGPU.lib`/`osdCPU.lib` pxrTargets.cmake patching hack
- Validate USD version and Python lib before reusing a cached `build/usd` directory (prevents stale version mismatch)
- Add thorough prerequisite checks with actionable error messages:
  - Git and CMake presence and minimum version
  - Visual Studio 2022 with C++ desktop workload (not just VS installed)
  - Disk space (~3 GB required)
  - Download integrity (catches truncated files)
  - Final executable verification
- Fix argument quoting for the VS generator name (use direct `& cmake` instead of `Start-Process`)
- Simplify `windows-start.bat` PATH setup
- Add **GitHub Actions CI** (`windows-build.yml`):
  - Builds on push to develop/main and on PRs
  - Downloads USD from NVIDIA directly (no redistribution), caches between runs
  - On **tag push** (`v*`): packages a portable self-contained bundle via `cmake --install` and creates a **GitHub Release** with the zip attached

## Test plan
- [x] Clean build from empty `build/` directory — download, extract, configure, compile all succeed
- [x] Built executable launches and reports `USD 2508`
- [x] `windows-start.bat` launches the built executable correctly
- [x] Portable install via `cmake --install` produces a working self-contained bundle
- [x] Re-running the script with existing USD skips the download step
- [x] CI passes on `windows-latest` runner (fresh download + build)
- [x] CI passes with cached USD (skips download, ~3.5 min build)
- [x] Tag push triggers release with downloadable portable zip
- [x] Test release verified at https://github.com/oumad/usdtweak/releases/tag/v0.0.1-test