### PR TITLE
Twiki: multi-provider LLM support (Ollama / OpenAI-compatible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build*
 /src/generated/
+# ImGui writes a default layout file into the CWD when run from the repo root
+/imgui.ini
 # pixi environments
 .pixi/*
 !.pixi/config.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,31 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # Remove warnings coming from usd and enable default multithreaded compilation on windows
+# /Zc:inline- is REQUIRED on MSVC: USD's TF_REGISTRY_FUNCTION / ARCH_CONSTRUCTOR
+# emit their registration entry as an unreferenced const in a custom .pxrctor
+# section. MSVC's default /Zc:inline drops unreferenced COMDAT data at *compile*
+# time, so the entry never reaches the object file and no addon registers (empty
+# Tools menu). clang/gcc protect it with __attribute__((used)); MSVC has no
+# equivalent, so we must keep the data with /Zc:inline-. Pairs with /OPT:NOREF
+# (below) which stops the linker from stripping it afterwards.
 target_compile_options(usdtweak PRIVATE
-	$<$<CXX_COMPILER_ID:MSVC>:/MP /wd4244 /wd4305 /wd4996>
+	$<$<CXX_COMPILER_ID:MSVC>:/MP /wd4244 /wd4305 /wd4996 /Zc:inline->
 	$<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated>)
 
 # NOMINMAX
 target_compile_definitions(usdtweak PRIVATE NOMINMAX)
+
+# Keep USD's TF_REGISTRY_FUNCTION / ARCH_CONSTRUCTOR entries alive on MSVC.
+# Those entries (used by addons to self-register) live in a custom .pxrctor
+# section that nothing else references. When linking an *executable*, MSVC's
+# /OPT:REF strips them as unreferenced, so no addon registers and the Tools
+# menu is empty. On Linux/macOS __attribute__((used)) protects them; MSVC has
+# no equivalent, so we disable reference elimination for this target. (USD's
+# own registry functions are unaffected: they live in the USD DLLs, whose
+# exported symbols keep the section.)
+if (MSVC)
+    target_link_options(usdtweak PRIVATE /OPT:NOREF)
+endif()
 
 # Remove TBB deprecation warnings
 add_compile_definitions(TBB_SUPPRESS_DEPRECATED_MESSAGES)

--- a/src/Editor.cpp
+++ b/src/Editor.cpp
@@ -1326,3 +1326,8 @@ void Editor::Draw() {
 void Editor::LoadSettings() { _settings = ResourcesLoader::GetEditorSettings(); }
 
 void Editor::SaveSettings() const { ResourcesLoader::GetEditorSettings() = _settings; }
+
+void Editor::PersistSettings() const {
+    SaveSettings();                  // sync the working copy into the shared store
+    ResourcesLoader::SaveSettings(); // write the shared store to the config file
+}

--- a/src/Editor.h
+++ b/src/Editor.h
@@ -58,6 +58,12 @@ class Editor {
     /// Not for general use — prefer the typed addon accessors in addons/Api.h.
     EditorSettings &GetSettingsForAddons() { return _settings; }
 
+    /// Flush the current settings to the config file immediately. Settings are
+    /// otherwise only written on a clean shutdown, so this exists for changes
+    /// (e.g. an addon's Apply button) that must survive a crash or force-quit.
+    /// Syncs the editor's working copy into the shared store, then writes it.
+    void PersistSettings() const;
+
     /// Returns the selected primspec
     /// There should be one selected primspec per layer ideally, so it's very likely this function will move
     Selection &GetSelection() { return _selection; }

--- a/src/addons/Api.cpp
+++ b/src/addons/Api.cpp
@@ -105,5 +105,8 @@ std::string GetAddonString(const std::string &addonId, const std::string &key, c
 void SetAddonString(const std::string &addonId, const std::string &key, const std::string &value) {
     if (auto *s = _Settings()) s->SetAddonString(addonId, key, value);
 }
+void PersistSettings() {
+    if (gEditor) gEditor->PersistSettings();
+}
 
 } // namespace usdtweak

--- a/src/addons/Api.h
+++ b/src/addons/Api.h
@@ -86,6 +86,11 @@ void SetAddonBool(const std::string &addonId, const std::string &key, bool value
 std::string GetAddonString(const std::string &addonId, const std::string &key, const std::string &defaultValue = "");
 void SetAddonString(const std::string &addonId, const std::string &key, const std::string &value);
 
+/// Write the settings (including the per-addon values set above) to the config
+/// file now. Settings are otherwise only persisted on a clean shutdown, so call
+/// this after a Set* that must survive a crash/force-quit (e.g. an Apply button).
+void PersistSettings();
+
 // ---------------------------------------------------------------- internal
 // Called by Editor on construction / destruction. Not for addon use.
 void _RegisterEditor(Editor *editor);

--- a/src/addons/Twiki/AgentChatPanel.cpp
+++ b/src/addons/Twiki/AgentChatPanel.cpp
@@ -4,11 +4,10 @@
 #include <imgui_markdown.h>
 #include <imgui_stdlib.h>
 
-#include "AnthropicBackend.h"
 #include "JsHelpers.h"
 #include "ResourcesLoader.h"
 #include "UsdTools.h"
-#include "addons/Api.h"   // usdtweak::{Set,Add}StagePathSelection, FrameCameraOnSelection, {Get,Set}AddonString
+#include "addons/Api.h"   // usdtweak::{Set,Add}StagePathSelection, FrameCameraOnSelection, {Get,Set}AddonString, PersistSettings
 
 #include <algorithm>
 #include <chrono>
@@ -431,21 +430,43 @@ AgentChatPanel::~AgentChatPanel() {
 }
 
 bool AgentChatPanel::_LazyInit(std::string* errOut) {
+    // Settings are loaded once at the top of Draw(), which always runs before
+    // this (reached only from the Chat tab's submit path).
     if (_initialized) return true;
+    return _RebuildBackend(errOut);
+}
 
-    const char* keyEnv = std::getenv("ANTHROPIC_API_KEY");
-    if (!keyEnv || !*keyEnv) {
-        *errOut = "ANTHROPIC_API_KEY is not set in the environment.\n"
-                  "Set it before launching usdtweak (e.g. in your shell rc) "
-                  "and restart, or paste it via the Settings menu (TODO).";
+bool AgentChatPanel::_RebuildBackend(std::string* errOut) {
+    const std::string key = ResolveApiKey(_provider, _apiKey);
+    if (ProviderRequiresKey(_provider) && key.empty()) {
+        if (errOut) {
+            const char* env = ApiKeyEnvVar(_provider);
+            *errOut = std::string(ProviderDisplayName(_provider)) +
+                      " needs an API key — paste one in the Settings tab" +
+                      (env ? std::string(" or set ") + env + " before launch"
+                           : std::string()) + ".";
+        }
         return false;
     }
 
-    const char* modelEnv = std::getenv("ANTHROPIC_MODEL");
-    std::string model = (modelEnv && *modelEnv) ? modelEnv : "claude-sonnet-4-6";
+    std::string model = _model.empty() ? DefaultModel(_provider) : _model;
+    if (model.empty()) {
+        if (errOut) *errOut = "No model selected. Pick one in the Settings tab "
+                              "(click \"Refresh list\").";
+        return false;
+    }
 
-    _InitToolState();  // ensure _allTools/prefs exist before we build the set
-    auto backend = std::make_unique<AnthropicBackend>(keyEnv, model);
+    _InitToolState();  // ensure _allTools / tool prefs exist before we build the set
+    auto backend = LLMBackend::Create(ProviderBackendType(_provider),
+                                      key, model, _baseUrl);
+    if (!backend) {
+        if (errOut) *errOut = "Could not construct a backend for the selected "
+                              "provider.";
+        return false;
+    }
+
+    // Replaces any previous orchestrator/backend; the dispatcher (and its
+    // lists) is a panel member and survives the swap.
     _orchestrator = std::make_unique<AgentOrchestrator>(
         std::move(backend), _dispatcher, _ActiveToolDefs());
     _initialized = true;
@@ -514,6 +535,56 @@ void AgentChatPanel::_SaveToolPrefs() const {
     usdtweak::SetAddonString("Twiki", "disabled_tools", csv);
 }
 
+void AgentChatPanel::_LoadSettings() {
+    const std::string id = "Twiki";
+    Provider p;
+    if (ProviderFromString(usdtweak::GetAddonString(id, "provider", ""), p))
+        _provider = p;
+    _baseUrl = usdtweak::GetAddonString(id, "baseUrl", "");
+    _apiKey  = usdtweak::GetAddonString(id, "apiKey",  "");
+    _model   = usdtweak::GetAddonString(id, "model",   "");
+
+    // Back-compat with the old env-only configuration.
+    if (_model.empty() && _provider == Provider::Anthropic) {
+        if (const char* m = std::getenv("ANTHROPIC_MODEL")) {
+            if (*m) _model = m;
+        }
+    }
+}
+
+void AgentChatPanel::_SaveSettings() const {
+    const std::string id = "Twiki";
+    usdtweak::SetAddonString(id, "provider", ProviderToString(_provider));
+    usdtweak::SetAddonString(id, "baseUrl",  _baseUrl);
+    usdtweak::SetAddonString(id, "apiKey",   _apiKey);
+    usdtweak::SetAddonString(id, "model",    _model);
+    // SetAddonString only updates the in-memory settings map; the config file is
+    // otherwise written only on a clean shutdown. Flush now (syncs the editor's
+    // working copy into the shared store, then writes it) so the choice survives
+    // a crash, kill, or the next launch regardless of how we exit.
+    usdtweak::PersistSettings();
+}
+
+void AgentChatPanel::_RefreshModels() {
+    if (_fetchingModels) return;  // one fetch at a time
+    _fetchingModels = true;
+    _modelsStatus   = "fetching…";
+    // Capture the current config by value; the worker must not touch `this`
+    // (Draw() applies the result on the UI thread when the future resolves).
+    const Provider    provider = _provider;
+    const std::string baseUrl  = _baseUrl;
+    const std::string apiKey   = _apiKey;
+    _modelsFuture = std::async(std::launch::async, [provider, baseUrl, apiKey]() {
+        ModelFetchResult r;
+        std::string err;
+        r.models = FetchModels(provider, baseUrl, apiKey, &err);
+        r.status = !r.models.empty()
+                       ? std::to_string(r.models.size()) + " models"
+                       : (err.empty() ? "no models found" : err);
+        return r;
+    });
+}
+
 std::string AgentChatPanel::_BuildSystemPrompt() const {
     // Live scene context is captured by the worker thread when each tool
     // runs. The system prompt only carries instructions and meta — keeping
@@ -573,6 +644,9 @@ void AgentChatPanel::Draw() {
 
     _InitToolState();  // build the tool list + load activation prefs (once)
 
+    // Load persisted backend settings once, before anything reads them.
+    if (!_settingsLoaded) { _LoadSettings(); _settingsLoaded = true; }
+
     // ----- poll background turn ------------------------------------------
     if (_pending.valid() &&
         _pending.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
@@ -589,6 +663,15 @@ void AgentChatPanel::Draw() {
             _pendingSink.reset();
         }
         _scrollToBottom = true;
+    }
+
+    // ----- poll background model fetch (Settings tab) --------------------
+    if (_modelsFuture.valid() &&
+        _modelsFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+        ModelFetchResult r = _modelsFuture.get();
+        _models         = std::move(r.models);
+        _modelsStatus   = std::move(r.status);
+        _fetchingModels = false;
     }
 
     // Tabs: Chat (the conversation, unchanged) + Lists (agent-curated prim
@@ -626,6 +709,10 @@ void AgentChatPanel::Draw() {
                  _allTools.size() - _disabledTools.size(), _allTools.size());
         if (ImGui::BeginTabItem(toolsLabel)) {
             _DrawToolsTab();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Settings")) {
+            _DrawSettingsTab();
             ImGui::EndTabItem();
         }
         ImGui::EndTabBar();
@@ -1054,6 +1141,124 @@ void AgentChatPanel::_DrawListsTab(const std::vector<std::string>& names) {
         }
     }
 
+    ImGui::EndChild();
+}
+
+// ----- Settings tab ---------------------------------------------------------
+// Pick the LLM provider (Anthropic / any OpenAI-compatible endpoint / Ollama),
+// its base URL and key, and the model. "Refresh list" enumerates the provider's
+// models; "Apply & Save" rebuilds the backend and persists the choice.
+
+void AgentChatPanel::_DrawSettingsTab() {
+    ImGui::BeginChild("##twiki_settings", ImVec2(0, 0), false);
+
+    const bool busy = _pending.valid();
+    if (busy) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.85f, 0.8f, 0.5f, 1.0f));
+        ImGui::TextWrapped("A turn is in flight — settings are locked until it "
+                           "finishes.");
+        ImGui::PopStyleColor();
+        ImGui::Separator();
+    }
+    ImGui::BeginDisabled(busy);
+
+    // ----- provider -------------------------------------------------------
+    ImGui::TextUnformatted("Provider");
+    static const Provider kProviders[] = {
+        Provider::Anthropic, Provider::OpenAI, Provider::Ollama };
+    if (ImGui::BeginCombo("##twiki_provider", ProviderDisplayName(_provider))) {
+        for (Provider p : kProviders) {
+            const bool sel = (p == _provider);
+            if (ImGui::Selectable(ProviderDisplayName(p), sel) && p != _provider) {
+                _provider = p;
+                // Start from the new provider's defaults; the user overrides
+                // below. Clear the key too, so a key entered for one provider is
+                // never carried over and sent to a different host.
+                _baseUrl = DefaultBaseUrl(p);
+                _model   = DefaultModel(p);
+                _apiKey.clear();
+                _models.clear();
+                _modelsStatus.clear();
+            }
+            if (sel) ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
+
+    // ----- endpoint -------------------------------------------------------
+    ImGui::Spacing();
+    if (_provider == Provider::Anthropic) {
+        ImGui::TextDisabled("Endpoint: https://api.anthropic.com (fixed)");
+    } else {
+        ImGui::TextUnformatted("Base URL");
+        ImGui::SetNextItemWidth(-1);
+        ImGui::InputTextWithHint("##twiki_baseurl",
+                                 DefaultBaseUrl(_provider).c_str(), &_baseUrl);
+    }
+
+    // ----- API key --------------------------------------------------------
+    ImGui::Spacing();
+    if (ProviderRequiresKey(_provider)) {
+        ImGui::TextUnformatted("API key");
+        const char* env = ApiKeyEnvVar(_provider);
+        const std::string hint =
+            env ? (std::string("leave empty to use $") + env) : std::string();
+        ImGui::SetNextItemWidth(-1);
+        ImGui::InputTextWithHint("##twiki_apikey", hint.c_str(), &_apiKey,
+                                 ImGuiInputTextFlags_Password);
+    } else {
+        ImGui::TextDisabled("No API key required for Ollama.");
+    }
+
+    // ----- model ----------------------------------------------------------
+    ImGui::Spacing();
+    ImGui::TextUnformatted("Model");
+    ImGui::SetNextItemWidth(-120);
+    ImGui::InputTextWithHint("##twiki_model", "model id", &_model);
+    ImGui::SameLine();
+    ImGui::BeginDisabled(_fetchingModels);
+    if (ImGui::Button("Refresh list", ImVec2(-1, 0))) _RefreshModels();
+    ImGui::EndDisabled();
+    if (!_modelsStatus.empty())
+        ImGui::TextDisabled("%s", _modelsStatus.c_str());
+
+    if (!_models.empty()) {
+        ImGui::BeginChild("##twiki_modellist",
+                          ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 6),
+                          true);
+        for (const ModelInfo& mi : _models) {
+            std::string label = mi.id;
+            if (!mi.toolCapable) label += "   (no tool support)";
+            if (ImGui::Selectable(label.c_str(), mi.id == _model))
+                _model = mi.id;
+        }
+        ImGui::EndChild();
+        ImGui::TextDisabled("Twiki relies on tool-calling — prefer a model that "
+                            "lists tool support.");
+    }
+
+    // ----- apply ----------------------------------------------------------
+    ImGui::Spacing();
+    ImGui::Separator();
+    if (ImGui::Button("Apply & Save")) {
+        _SaveSettings();
+        _initialized = false;          // force a rebuild with the new settings
+        std::string err;
+        if (_RebuildBackend(&err)) {
+            _lastError.clear();
+            _modelsStatus = std::string("applied: ") +
+                            ProviderDisplayName(_provider) + " / " + _model;
+        } else {
+            _lastError    = err;       // also shown on the Chat tab
+            _modelsStatus = err;
+        }
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("Active: %s / %s",
+                        ProviderDisplayName(_provider),
+                        _model.empty() ? "(none)" : _model.c_str());
+
+    ImGui::EndDisabled();
     ImGui::EndChild();
 }
 

--- a/src/addons/Twiki/AgentChatPanel.h
+++ b/src/addons/Twiki/AgentChatPanel.h
@@ -2,6 +2,7 @@
 
 #include "AgentOrchestrator.h"
 #include "LLMBackend.h"
+#include "ProviderCatalog.h"
 #include "UsdToolDispatcher.h"
 
 #include <future>
@@ -70,6 +71,23 @@ private:
     // Backend + orchestrator are constructed lazily on first send so the
     // panel costs nothing while it sits closed.
     bool _LazyInit(std::string* errOut);
+
+    // (Re)construct the backend + orchestrator from the current provider
+    // settings. Returns false and fills errOut on a configuration problem
+    // (e.g. a key-requiring provider with no key). Never called while a turn
+    // is in flight (the worker owns the orchestrator).
+    bool _RebuildBackend(std::string* errOut);
+
+    // Settings persistence via usdtweak::Get/SetAddonString (the .ini file).
+    // _LoadSettings runs once before the first Draw; _SaveSettings on Apply.
+    void _LoadSettings();
+    void _SaveSettings() const;
+
+    // Settings tab: pick provider, endpoint, key, and model. _RefreshModels
+    // launches model discovery on a worker thread (into _modelsFuture); Draw()
+    // polls it and applies the result, so the UI never blocks on the network.
+    void _DrawSettingsTab();
+    void _RefreshModels();
 
     // Build the per-turn system prompt with live scene context.
     std::string _BuildSystemPrompt() const;
@@ -144,6 +162,23 @@ private:
     std::unique_ptr<AgentOrchestrator> _orchestrator;  // lazy
     bool                             _initialized = false;
     bool                             _scrollToBottom = false;
+
+    // ----- backend configuration (editable in the Settings tab) -----------
+    Provider    _provider = Provider::Anthropic;
+    std::string _baseUrl;      // empty => provider default
+    std::string _apiKey;       // empty => fall back to the provider env var
+    std::string _model;
+    bool        _settingsLoaded = false;
+
+    // Model picker state (Settings tab). _RefreshModels runs FetchModels on a
+    // worker thread into _modelsFuture; Draw() polls it and moves the result
+    // into _models/_modelsStatus. _fetchingModels is true while a fetch is in
+    // flight. The worker captures its inputs by value and never touches `this`.
+    struct ModelFetchResult { std::vector<ModelInfo> models; std::string status; };
+    std::vector<ModelInfo>        _models;
+    std::string                   _modelsStatus;   // "5 models" / an error / ""
+    bool                          _fetchingModels = false;
+    std::future<ModelFetchResult> _modelsFuture;
 };
 
 } // namespace UsdAgent

--- a/src/addons/Twiki/AnthropicBackend.cpp
+++ b/src/addons/Twiki/AnthropicBackend.cpp
@@ -76,8 +76,9 @@ LLMResponse AnthropicBackend::Send(const Conversation& conv,
         {"anthropic-version", "2023-06-01"},
     };
 
+    // Shared chat read timeout (see kChatTimeoutSeconds in LLMBackend.h).
     HttpResponse http = HttpPostJson("https://api.anthropic.com/v1/messages",
-                                     headers, body);
+                                     headers, body, kChatTimeoutSeconds);
 
     if (http.status == 0) {
         LLMResponse r;

--- a/src/addons/Twiki/CMakeLists.txt
+++ b/src/addons/Twiki/CMakeLists.txt
@@ -64,6 +64,7 @@ usdtweak_add_addon(Twiki
         LLMBackend.cpp
         AnthropicBackend.cpp
         OpenAIBackend.cpp
+        ProviderCatalog.cpp
         HttpClient.cpp
         UsdToolDispatcher.cpp
         UsdTools.cpp
@@ -74,6 +75,7 @@ usdtweak_add_addon(Twiki
         LLMBackend.h
         AnthropicBackend.h
         OpenAIBackend.h
+        ProviderCatalog.h
         HttpClient.h
         UsdToolDispatcher.h
         UsdTools.h
@@ -99,6 +101,7 @@ set(_twiki_agent_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/LLMBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AnthropicBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/OpenAIBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ProviderCatalog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/HttpClient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/UsdToolDispatcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/UsdTools.cpp
@@ -148,14 +151,22 @@ if (USDTWEAK_BUILD_TWIKI_TESTS)
             ${CMAKE_SOURCE_DIR}/src
         )
         target_link_libraries(${name} PRIVATE ${PXR_LIBRARIES} ${_twiki_tls_libs})
-        target_compile_definitions(${name} PRIVATE ${_twiki_tls_define})
-        set_target_properties(${name} PROPERTIES FOLDER "addons/Twiki/tests")
+        # Mirror the compile environment of the main usdtweak target. NOMINMAX is
+        # essential on MSVC: without it windows.h's min/max macros break USD's
+        # robin_hash.h (error C1201). The /wd flags silence the same USD warnings.
+        target_compile_definitions(${name} PRIVATE
+            ${_twiki_tls_define} NOMINMAX TBB_SUPPRESS_DEPRECATED_MESSAGES)
+        target_compile_options(${name} PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/wd4244 /wd4305 /wd4996>)
+        set_target_properties(${name} PROPERTIES
+            FOLDER "addons/Twiki/tests"
+            CXX_STANDARD 17)
         add_custom_target(run_${name}
             COMMAND ${name}
             DEPENDS ${name}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
-        if (${add_to_check})
+        if (add_to_check)
             add_dependencies(check run_${name})
         endif()
     endfunction()
@@ -178,6 +189,11 @@ if (USDTWEAK_BUILD_TWIKI_TESTS)
     _twiki_add_test(test_live_tool_call FALSE
         ${_twiki_agent_sources}
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/TestLiveToolCall.cpp
+    )
+
+    _twiki_add_test(test_live_ollama FALSE
+        ${_twiki_agent_sources}
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/TestLiveOllama.cpp
     )
 
     _twiki_add_test(test_usd_dispatcher TRUE

--- a/src/addons/Twiki/HttpClient.cpp
+++ b/src/addons/Twiki/HttpClient.cpp
@@ -7,6 +7,9 @@
 #include <sys/stat.h>
 
 #include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
 
 namespace UsdAgent {
 
@@ -57,6 +60,43 @@ const char* _ResolveCaBundle() {
     return nullptr;
 }
 
+// ---------------------------------------------------------------------------
+// Persistent, keep-alive clients keyed by "scheme://host:port".
+//
+// Previously every request created and destroyed its own httplib::Client,
+// opening a brand-new TCP connection each time. The agent's ReAct loop fires
+// several requests per turn, so a session churned through many short-lived
+// connections; on Windows each closed client socket lingers in TIME_WAIT for
+// minutes, and under contention (e.g. another process also hammering the same
+// server) the ephemeral-port pool runs dry and connect() starts failing with
+// "Could not establish connection".
+//
+// Reusing one keep-alive client per host collapses a whole session onto a
+// single reused socket. httplib transparently reconnects if the server drops
+// the idle connection. All HTTP goes through g_clientsMu, which also makes the
+// non-thread-safe httplib::Client safe to share (requests are serialized — the
+// agent never issues two at once).
+std::mutex g_clientsMu;
+std::map<std::string, std::unique_ptr<httplib::Client>> g_clients;
+
+httplib::Client& _AcquireClient(const std::string& schemeHost, int timeoutSeconds) {
+    std::unique_ptr<httplib::Client>& slot = g_clients[schemeHost];
+    if (!slot) {
+        slot = std::make_unique<httplib::Client>(schemeHost);
+        slot->set_keep_alive(true);
+        slot->enable_server_certificate_verification(true);
+        slot->set_follow_location(true);
+        if (const char* caBundle = _ResolveCaBundle()) {
+            slot->set_ca_cert_path(caBundle);
+        }
+    }
+    // Timeouts can differ per call (fast model-list GET vs slow chat POST).
+    slot->set_connection_timeout(std::chrono::seconds(timeoutSeconds));
+    slot->set_read_timeout      (std::chrono::seconds(timeoutSeconds));
+    slot->set_write_timeout     (std::chrono::seconds(timeoutSeconds));
+    return *slot;
+}
+
 } // namespace
 
 HttpResponse HttpPostJson(const std::string&             url,
@@ -71,14 +111,33 @@ HttpResponse HttpPostJson(const std::string&             url,
         return out;
     }
 
-    httplib::Client client(schemeHost);
-    client.set_connection_timeout(std::chrono::seconds(timeoutSeconds));
-    client.set_read_timeout      (std::chrono::seconds(timeoutSeconds));
-    client.set_write_timeout     (std::chrono::seconds(timeoutSeconds));
-    client.enable_server_certificate_verification(true);
-    client.set_follow_location(true);
-    if (const char* caBundle = _ResolveCaBundle()) {
-        client.set_ca_cert_path(caBundle);
+    httplib::Headers httpHeaders;
+    for (const HttpHeader& h : headers) {
+        httpHeaders.emplace(h.name, h.value);
+    }
+
+    std::lock_guard<std::mutex> lock(g_clientsMu);
+    httplib::Client& client = _AcquireClient(schemeHost, timeoutSeconds);
+
+    auto result = client.Post(path, httpHeaders, jsonBody, "application/json");
+    if (!result) {
+        out.error = "request failed: " + httplib::to_string(result.error());
+        return out;
+    }
+    out.status = result->status;
+    out.body   = result->body;
+    return out;
+}
+
+HttpResponse HttpGetJson(const std::string&             url,
+                         const std::vector<HttpHeader>& headers,
+                         int                            timeoutSeconds) {
+    HttpResponse out;
+
+    std::string schemeHost, path;
+    if (!_SplitUrl(url, schemeHost, path)) {
+        out.error = "malformed URL: " + url;
+        return out;
     }
 
     httplib::Headers httpHeaders;
@@ -86,7 +145,10 @@ HttpResponse HttpPostJson(const std::string&             url,
         httpHeaders.emplace(h.name, h.value);
     }
 
-    auto result = client.Post(path, httpHeaders, jsonBody, "application/json");
+    std::lock_guard<std::mutex> lock(g_clientsMu);
+    httplib::Client& client = _AcquireClient(schemeHost, timeoutSeconds);
+
+    auto result = client.Get(path, httpHeaders);
     if (!result) {
         out.error = "request failed: " + httplib::to_string(result.error());
         return out;

--- a/src/addons/Twiki/HttpClient.h
+++ b/src/addons/Twiki/HttpClient.h
@@ -27,4 +27,11 @@ HttpResponse HttpPostJson(const std::string&             url,
                           const std::string&             jsonBody,
                           int                            timeoutSeconds = 60);
 
+// One-shot GET. Used to enumerate models from a provider (e.g. Ollama's
+// /api/tags or an OpenAI-compatible /v1/models). Same URL/scheme handling and
+// error semantics as HttpPostJson.
+HttpResponse HttpGetJson(const std::string&             url,
+                         const std::vector<HttpHeader>& headers,
+                         int                            timeoutSeconds = 30);
+
 } // namespace UsdAgent

--- a/src/addons/Twiki/LLMBackend.cpp
+++ b/src/addons/Twiki/LLMBackend.cpp
@@ -1,5 +1,8 @@
 #include "LLMBackend.h"
 
+#include "AnthropicBackend.h"
+#include "OpenAIBackend.h"
+
 #include <utility>
 
 namespace UsdAgent {
@@ -49,12 +52,20 @@ Message Message::ToolResult(std::string id,
     return m;
 }
 
-// Factory definition is intentionally deferred: it will be filled in once the
-// concrete backends compile and HTTP support lands (Step 3+).
-std::unique_ptr<LLMBackend> LLMBackend::Create(const std::string&,
-                                               const std::string&,
-                                               const std::string&,
-                                               const std::string&) {
+// Factory: maps a backend type string to a concrete backend.
+//   "anthropic"          -> AnthropicBackend (fixed Messages API endpoint)
+//   "openai" / "ollama"  -> OpenAIBackend against `baseUrl` (Ollama speaks the
+//                           OpenAI Chat Completions wire format)
+std::unique_ptr<LLMBackend> LLMBackend::Create(const std::string& backendType,
+                                               const std::string& apiKey,
+                                               const std::string& model,
+                                               const std::string& baseUrl) {
+    if (backendType == "anthropic") {
+        return std::make_unique<AnthropicBackend>(apiKey, model);
+    }
+    if (backendType == "openai" || backendType == "ollama") {
+        return std::make_unique<OpenAIBackend>(apiKey, model, baseUrl);
+    }
     return nullptr;
 }
 

--- a/src/addons/Twiki/LLMBackend.h
+++ b/src/addons/Twiki/LLMBackend.h
@@ -88,6 +88,13 @@ struct LLMResponse {
     LLMUsage    usage;
 };
 
+// Read timeout for a chat request, shared by all backends. Generous on purpose:
+// a local Ollama server running a large "thinking" model can take a minute or
+// more to first byte, especially on the cold first request (model load) with
+// the agent's full tool-def payload. Chat runs on a worker thread, so a long
+// ceiling never blocks the UI.
+inline constexpr int kChatTimeoutSeconds = 600;
+
 class LLMBackend {
 public:
     virtual ~LLMBackend() = default;

--- a/src/addons/Twiki/OpenAIBackend.cpp
+++ b/src/addons/Twiki/OpenAIBackend.cpp
@@ -2,6 +2,7 @@
 
 #include "HttpClient.h"
 #include "JsHelpers.h"
+#include "ProviderCatalog.h"   // OpenAiEndpoint
 
 #include <pxr/base/js/json.h>
 
@@ -47,17 +48,18 @@ LLMResponse OpenAIBackend::Send(const Conversation& conv,
     JsObject reqJson = BuildRequest(conv, tools, _model);
     std::string body = JsToString(JsValue(reqJson));
 
-    std::string base = _baseUrl.empty() ? std::string("https://api.openai.com")
-                                        : _baseUrl;
-    // Trim trailing slash so we don't end up with a // in the URL.
-    if (!base.empty() && base.back() == '/') base.pop_back();
+    // Tolerates a trailing slash and a base URL that already ends in "/v1"
+    // (see ProviderCatalog::OpenAiEndpoint); shared with model discovery so
+    // both paths resolve the endpoint identically.
+    const std::string url = OpenAiEndpoint(_baseUrl, "chat/completions");
 
-    std::vector<HttpHeader> headers = {
-        {"Authorization", "Bearer " + _apiKey},
-    };
+    // Only send Authorization when we actually have a key: keyless endpoints
+    // (Ollama, some local servers) reject a literal "Bearer " with an empty
+    // token on stricter proxies.
+    std::vector<HttpHeader> headers;
+    if (!_apiKey.empty()) headers.push_back({"Authorization", "Bearer " + _apiKey});
 
-    HttpResponse http = HttpPostJson(base + "/v1/chat/completions",
-                                     headers, body);
+    HttpResponse http = HttpPostJson(url, headers, body, kChatTimeoutSeconds);
 
     if (http.status == 0) {
         LLMResponse r;

--- a/src/addons/Twiki/ProviderCatalog.cpp
+++ b/src/addons/Twiki/ProviderCatalog.cpp
@@ -1,0 +1,194 @@
+#include "ProviderCatalog.h"
+
+#include "HttpClient.h"
+#include "JsHelpers.h"
+
+#include <pxr/base/js/json.h>
+#include <pxr/base/js/value.h>
+
+#include <cstdlib>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace UsdAgent {
+
+namespace {
+
+std::string _TrimTrailingSlash(std::string s) {
+    while (!s.empty() && s.back() == '/') s.pop_back();
+    return s;
+}
+
+bool _EndsWith(const std::string& s, const std::string& suffix) {
+    return s.size() >= suffix.size() &&
+           s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+// Parse an OpenAI-style {"data":[{"id":...}]} model list.
+std::vector<ModelInfo> _ParseOpenAIModels(const JsValue& root) {
+    std::vector<ModelInfo> out;
+    if (!root.IsObject()) return out;
+    for (const JsValue& m : JsGetArray(root.GetJsObject(), "data")) {
+        if (!m.IsObject()) continue;
+        const std::string id = JsGetString(m.GetJsObject(), "id");
+        if (!id.empty()) out.push_back(ModelInfo{id, /*toolCapable=*/true});
+    }
+    return out;
+}
+
+// Parse Ollama's {"models":[{"name":...,"capabilities":[...]}]} list.
+std::vector<ModelInfo> _ParseOllamaTags(const JsValue& root) {
+    std::vector<ModelInfo> out;
+    if (!root.IsObject()) return out;
+    for (const JsValue& m : JsGetArray(root.GetJsObject(), "models")) {
+        if (!m.IsObject()) continue;
+        const JsObject& obj = m.GetJsObject();
+        const std::string name = JsGetString(obj, "name");
+        if (name.empty()) continue;
+        bool tools = false;
+        for (const JsValue& cap : JsGetArray(obj, "capabilities")) {
+            if (cap.IsString() && cap.GetString() == "tools") { tools = true; break; }
+        }
+        out.push_back(ModelInfo{name, tools});
+    }
+    return out;
+}
+
+std::vector<ModelInfo> _GetJsonModels(const std::string&             url,
+                                      const std::vector<HttpHeader>& headers,
+                                      bool                           ollama,
+                                      std::string*                   err) {
+    HttpResponse http = HttpGetJson(url, headers, /*timeoutSeconds=*/8);
+    if (http.status == 0) {
+        if (err) *err = "could not reach " + url + " (" + http.error + ")";
+        return {};
+    }
+    if (http.status < 200 || http.status >= 300) {
+        if (err) *err = "HTTP " + std::to_string(http.status) + " from " + url;
+        return {};
+    }
+    JsValue root = JsParseString(http.body);
+    std::vector<ModelInfo> models =
+        ollama ? _ParseOllamaTags(root) : _ParseOpenAIModels(root);
+    if (models.empty() && err) *err = "no models found at " + url;
+    return models;
+}
+
+} // namespace
+
+const char* ProviderToString(Provider p) {
+    switch (p) {
+        case Provider::Anthropic: return "anthropic";
+        case Provider::OpenAI:    return "openai";
+        case Provider::Ollama:    return "ollama";
+    }
+    return "anthropic";
+}
+
+bool ProviderFromString(const std::string& s, Provider& out) {
+    if (s == "anthropic") { out = Provider::Anthropic; return true; }
+    if (s == "openai")    { out = Provider::OpenAI;    return true; }
+    if (s == "ollama")    { out = Provider::Ollama;    return true; }
+    return false;
+}
+
+const char* ProviderDisplayName(Provider p) {
+    switch (p) {
+        case Provider::Anthropic: return "Anthropic (Claude)";
+        case Provider::OpenAI:    return "OpenAI-compatible";
+        case Provider::Ollama:    return "Ollama";
+    }
+    return "?";
+}
+
+const char* ProviderBackendType(Provider p) {
+    // Ollama speaks the OpenAI Chat Completions wire format, so it reuses the
+    // OpenAI backend; only model discovery differs.
+    return (p == Provider::Anthropic) ? "anthropic" : "openai";
+}
+
+std::string DefaultBaseUrl(Provider p) {
+    switch (p) {
+        case Provider::Anthropic: return "";                          // fixed in backend
+        case Provider::OpenAI:    return "https://api.openai.com";
+        case Provider::Ollama:    return "http://localhost:11434";
+    }
+    return "";
+}
+
+std::string DefaultModel(Provider p) {
+    switch (p) {
+        case Provider::Anthropic: return "claude-sonnet-4-6";
+        case Provider::OpenAI:    return "";
+        case Provider::Ollama:    return "";
+    }
+    return "";
+}
+
+const char* ApiKeyEnvVar(Provider p) {
+    switch (p) {
+        case Provider::Anthropic: return "ANTHROPIC_API_KEY";
+        case Provider::OpenAI:    return "OPENAI_API_KEY";
+        case Provider::Ollama:    return nullptr;
+    }
+    return nullptr;
+}
+
+bool ProviderRequiresKey(Provider p) {
+    return p == Provider::Anthropic || p == Provider::OpenAI;
+}
+
+std::string ResolveApiKey(Provider p, const std::string& userKey) {
+    if (!userKey.empty()) return userKey;
+    if (const char* env = ApiKeyEnvVar(p)) {
+        if (const char* v = std::getenv(env)) {
+            if (*v) return v;
+        }
+    }
+    return "";
+}
+
+std::string OpenAiEndpoint(const std::string& baseUrl, const std::string& resource) {
+    std::string base = _TrimTrailingSlash(
+        baseUrl.empty() ? DefaultBaseUrl(Provider::OpenAI) : baseUrl);
+    // If the base already carries the /v1 segment, don't add a second one.
+    const std::string v1 = _EndsWith(base, "/v1") ? "" : "/v1";
+    return base + v1 + "/" + resource;
+}
+
+std::vector<ModelInfo> FetchModels(Provider           p,
+                                   const std::string& baseUrl,
+                                   const std::string& apiKey,
+                                   std::string*       err) {
+    if (err) err->clear();
+    const std::string key = ResolveApiKey(p, apiKey);
+
+    switch (p) {
+        case Provider::Ollama: {
+            std::string base = _TrimTrailingSlash(
+                baseUrl.empty() ? DefaultBaseUrl(p) : baseUrl);
+            return _GetJsonModels(base + "/api/tags", {}, /*ollama=*/true, err);
+        }
+        case Provider::OpenAI: {
+            std::vector<HttpHeader> headers;
+            if (!key.empty()) headers.push_back({"Authorization", "Bearer " + key});
+            return _GetJsonModels(OpenAiEndpoint(baseUrl, "models"),
+                                  headers, /*ollama=*/false, err);
+        }
+        case Provider::Anthropic: {
+            if (key.empty()) {
+                if (err) *err = "set ANTHROPIC_API_KEY (or paste a key) to list models";
+                return {};
+            }
+            std::vector<HttpHeader> headers = {
+                {"x-api-key", key},
+                {"anthropic-version", "2023-06-01"},
+            };
+            return _GetJsonModels("https://api.anthropic.com/v1/models",
+                                  headers, /*ollama=*/false, err);
+        }
+    }
+    return {};
+}
+
+} // namespace UsdAgent

--- a/src/addons/Twiki/ProviderCatalog.h
+++ b/src/addons/Twiki/ProviderCatalog.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace UsdAgent {
+
+// The LLM providers Twiki can talk to.
+//   Anthropic - Claude Messages API (AnthropicBackend).
+//   OpenAI    - any OpenAI-compatible Chat Completions endpoint (OpenAIBackend):
+//               OpenAI itself, llama-server, vLLM, LM Studio, ...
+//   Ollama    - a local/remote Ollama server. Chat goes through the same
+//               OpenAI-compatible endpoint (OpenAIBackend), but model discovery
+//               uses Ollama's native /api/tags (which also reports per-model
+//               capabilities, e.g. whether the model supports tools).
+enum class Provider { Anthropic, OpenAI, Ollama };
+
+// Stable id used for settings persistence and the backend factory.
+const char* ProviderToString(Provider p);          // "anthropic" | "openai" | "ollama"
+bool        ProviderFromString(const std::string& s, Provider& out);
+
+// Human-readable label for the UI.
+const char* ProviderDisplayName(Provider p);
+
+// Backend type string passed to LLMBackend::Create. Ollama reuses the OpenAI
+// backend, so it maps to "openai".
+const char* ProviderBackendType(Provider p);
+
+// Sensible default endpoint for a freshly-selected provider. Empty for
+// Anthropic (its URL is fixed inside AnthropicBackend).
+std::string DefaultBaseUrl(Provider p);
+
+// A reasonable default model id (may be empty: Ollama/OpenAI users pick one).
+std::string DefaultModel(Provider p);
+
+// Environment variable consulted for the API key when the UI field is empty.
+// nullptr for providers that need no key (Ollama).
+const char* ApiKeyEnvVar(Provider p);
+
+// Whether a non-empty key is required to talk to the provider.
+bool ProviderRequiresKey(Provider p);
+
+// Effective API key: the user-supplied value if non-empty, else the provider's
+// environment variable (if any), else empty.
+std::string ResolveApiKey(Provider p, const std::string& userKey);
+
+// Build an OpenAI-style endpoint from a user-entered base URL and a resource
+// ("chat/completions" or "models"). Tolerates a trailing slash and a base URL
+// that already includes the "/v1" segment (a very common form for llama-server,
+// vLLM, LM Studio), so both "http://h:8080" and "http://h:8080/v1" resolve to
+// the same ".../v1/<resource>" without doubling. An empty base falls back to
+// the public OpenAI endpoint.
+std::string OpenAiEndpoint(const std::string& baseUrl, const std::string& resource);
+
+struct ModelInfo {
+    std::string id;
+    bool        toolCapable = true;   // false only when we positively know it isn't
+};
+
+// Best-effort model enumeration for a provider. Performs one blocking HTTP GET.
+// On success returns the models (possibly empty); on failure returns {} and
+// sets *err (when non-null) to a short human-readable reason. Never throws.
+std::vector<ModelInfo> FetchModels(Provider           p,
+                                   const std::string& baseUrl,
+                                   const std::string& apiKey,
+                                   std::string*       err = nullptr);
+
+} // namespace UsdAgent

--- a/src/addons/Twiki/tests/TestLiveOllama.cpp
+++ b/src/addons/Twiki/tests/TestLiveOllama.cpp
@@ -1,0 +1,130 @@
+// Live end-to-end test against an Ollama server reachable over its
+// OpenAI-compatible API. Exercises the two pieces that make Ollama work in
+// Twiki:
+//   1. ProviderCatalog::FetchModels(Ollama, ...)   -> model discovery (/api/tags)
+//   2. OpenAIBackend::Send(... tools ...)           -> a real tool-calling turn
+//
+// NOT part of the `check` aggregate — it needs network access to a running
+// Ollama. Run manually, pointing at your server:
+//
+//   OLLAMA_BASE_URL=http://localhost:11434 build/.../test_live_ollama
+//
+// Optional env vars:
+//   OLLAMA_BASE_URL  (default: http://localhost:11434)
+//   OLLAMA_MODEL     (default: first tool-capable model reported by the server)
+
+#include "JsHelpers.h"
+#include "LLMBackend.h"
+#include "OpenAIBackend.h"
+#include "ProviderCatalog.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+using namespace UsdAgent;
+
+namespace {
+
+JsObject MakeWeatherTool() {
+    JsObject props;
+    props["city"] = MakeStringParam("the city to get the weather for, e.g. Paris");
+
+    JsArray required;
+    required.push_back(JsValue(std::string("city")));
+
+    JsObject schema;
+    schema["type"]       = JsValue(std::string("object"));
+    schema["properties"] = JsValue(props);
+    schema["required"]   = JsValue(required);
+
+    JsObject t;
+    t["name"]        = JsValue(std::string("get_weather"));
+    t["description"] = JsValue(std::string("Get the current weather for a city."));
+    t["parameters"]  = JsValue(schema);
+    return t;
+}
+
+const char* TypeStr(LLMResponse::Type t) {
+    return t == LLMResponse::Type::FinalAnswer ? "FinalAnswer" : "ToolCall";
+}
+
+} // namespace
+
+int main() {
+    const char* baseEnv = std::getenv("OLLAMA_BASE_URL");
+    const std::string base = (baseEnv && *baseEnv) ? baseEnv
+                                                   : "http://localhost:11434";
+
+    // --- 1. Model discovery -------------------------------------------------
+    std::string err;
+    std::vector<ModelInfo> models = FetchModels(Provider::Ollama, base, "", &err);
+    if (models.empty()) {
+        std::fprintf(stdout,
+            "test_live_ollama: skipped (no models from %s: %s)\n",
+            base.c_str(), err.c_str());
+        return 0;  // treat an unreachable server as a skip, not a failure
+    }
+    std::fprintf(stdout, "test_live_ollama: %zu models from %s\n",
+                 models.size(), base.c_str());
+
+    std::string model;
+    if (const char* m = std::getenv("OLLAMA_MODEL")) {
+        if (*m) model = m;
+    }
+    if (model.empty()) {
+        for (const ModelInfo& mi : models) {
+            if (mi.toolCapable) { model = mi.id; break; }
+        }
+    }
+    if (model.empty()) {
+        std::fprintf(stderr,
+            "test_live_ollama: FAIL — no tool-capable model advertised by the "
+            "server (Twiki needs tool support)\n");
+        return 1;
+    }
+    std::fprintf(stdout, "test_live_ollama: using model '%s'\n", model.c_str());
+
+    // --- 2. A real tool-calling turn ---------------------------------------
+    OpenAIBackend backend(/*apiKey=*/"", model, base);
+
+    ToolDefs tools;
+    tools.push_back(JsValue(MakeWeatherTool()));
+
+    Conversation conv;
+    conv.push_back(Message::System(
+        "You are a helpful assistant. When asked about the weather you MUST "
+        "call the get_weather tool. Do not answer from memory."));
+    conv.push_back(Message::User("What's the weather in Paris right now?"));
+
+    LLMResponse r = backend.Send(conv, tools);
+    if (r.content.rfind("[openai error", 0) == 0) {
+        std::fprintf(stderr, "test_live_ollama: FAIL — backend error: %s\n",
+                     r.content.c_str());
+        return 1;
+    }
+
+    std::fprintf(stdout, "test_live_ollama: response type=%s\n", TypeStr(r.type));
+    if (r.type == LLMResponse::Type::ToolCall) {
+        std::fprintf(stdout, "test_live_ollama: tool='%s' args=%s\n",
+                     r.toolName.c_str(),
+                     JsToString(JsValue(r.toolArguments)).c_str());
+        if (r.toolName != "get_weather") {
+            std::fprintf(stderr,
+                "test_live_ollama: FAIL — expected get_weather, got '%s'\n",
+                r.toolName.c_str());
+            return 1;
+        }
+        std::fprintf(stdout, "test_live_ollama: OK (tool call parsed correctly)\n");
+        return 0;
+    }
+
+    // A final answer (no tool call) still proves the chat path works end to end,
+    // but means this particular model declined to use the tool. Pass with a
+    // warning rather than failing on model-dependent behavior.
+    std::fprintf(stdout,
+        "test_live_ollama: OK (chat path works, but model returned a final "
+        "answer instead of a tool call: %.120s...)\n", r.content.c_str());
+    return 0;
+}

--- a/src/resources/ResourcesLoader.cpp
+++ b/src/resources/ResourcesLoader.cpp
@@ -317,10 +317,14 @@ void ResourcesLoader::ScaleUI(float scaleValue) {
     ImGui::GetStyle().FontScaleMain = scaleValue;
 }
 
-ResourcesLoader::~ResourcesLoader() {
-    // Save the configuration file when the application closes the resources
+void ResourcesLoader::SaveSettings() {
     const std::string configFilePath = GetConfigFilePath();
     ImGui::SaveIniSettingsToDisk(configFilePath.c_str());
+}
+
+ResourcesLoader::~ResourcesLoader() {
+    // Save the configuration file when the application closes the resources
+    SaveSettings();
     ImGui::DestroyContext();
 }
 

--- a/src/resources/ResourcesLoader.h
+++ b/src/resources/ResourcesLoader.h
@@ -15,6 +15,12 @@ class ResourcesLoader {
     static EditorSettings &GetEditorSettings();
     static ViewportSettings &GetViewportSettings();
 
+    // Persist the current settings (including addon settings) to the config file
+    // immediately. Settings are otherwise only written on a clean shutdown (see
+    // the destructor), so anything that must survive a crash/kill should call
+    // this right after mutating a setting.
+    static void SaveSettings();
+
     // The following getter/setter should ultimately move to ApplicationSettings
     static int GetApplicationWidth();
     static int GetApplicationHeight();


### PR DESCRIPTION
## Summary

Adds **multi-provider LLM support** to the Twiki agent so it can talk to a local **Ollama** server or any **OpenAI-compatible** endpoint, not just Anthropic — configurable from a new **Settings** tab. Along the way it fixes two issues that affect Windows/MSVC more broadly.

Three self-contained commits:

### 1. Fix addons not registering on MSVC
USD's `TF_REGISTRY_FUNCTION` / `ARCH_CONSTRUCTOR` emit their registration entry as an unreferenced `const` in a custom `.pxrctor` section. On MSVC that entry is dropped at compile time by `/Zc:inline` (unreferenced COMDAT data) and again at link time by `/OPT:REF`, so **no addon registers at runtime and the Tools menu comes up empty**. clang/gcc keep it via `__attribute__((used))`; MSVC has no equivalent. Fixed by compiling the `usdtweak` target with `/Zc:inline-` and linking with `/OPT:NOREF` (both MSVC-only). Verified with `dumpbin` that the `.pxrctor` entry is emitted, and that all addons register at runtime.

### 2. Persist editor settings on demand, not only at clean shutdown
Settings (including the per-addon key/value bag) were written to the config file only from `ResourcesLoader`'s destructor, so a crash or force-quit lost any change, and an addon couldn't flush a setting right after an Apply. Adds `ResourcesLoader::SaveSettings()`, `Editor::PersistSettings()` (syncs the editor's working `EditorSettings` copy into the shared instance that gets dumped, then writes it), and exposes it to addons as `usdtweak::PersistSettings()`.

### 3. Twiki: multi-provider LLM support (Ollama / OpenAI-compatible)
- **Settings tab** to pick provider (Anthropic / OpenAI-compatible / Ollama), base URL, API key, and model, with a **Refresh** button that enumerates the server's models (marking tool-capable ones). Choices persist to the config immediately.
- Ollama speaks the OpenAI Chat Completions wire format, so its chat **reuses `OpenAIBackend` unchanged**; only model discovery differs (native `/api/tags`, which also reports tool capability). Wires up the previously-stubbed `LLMBackend::Create` factory and adds `ProviderCatalog` for provider presets + model discovery.
- **HTTP: keep-alive connection reuse** — one `httplib::Client` per host instead of a new connection per request. A ReAct turn fires several requests; the old churn exhausted Windows ephemeral ports (`Could not establish connection`).
- **Chat read timeout raised to 600s** for slow local "thinking" models.
- **Model discovery runs on a worker thread** so a bad/slow endpoint never freezes the UI.
- Base-URL joining tolerates a trailing slash and an existing `/v1` segment.
- Adds a gated live Ollama test (`test_live_ollama`, opt-in, not in `check`).
- Twiki stays **off by default** (`BUILD_TWIKI=OFF`).

## Testing
- Windows (VS 2022), `-DBUILD_TWIKI=ON`: the Twiki addon and its tests compile clean; the new `test_live_ollama` passes end-to-end against a real Ollama server (model discovery + a tool-calling round-trip through `OpenAIBackend`).
- Manually verified in-app (prior to rebase): provider/model selection, Refresh, persistence across restarts, and full agent turns against Ollama.
- Rebased onto current `develop`; the multi-provider changes merge cleanly with the newer tool-activation / traces work.

## Notes for reviewers
- The changeset went through an automated multi-dimension review; the async model fetch, base-URL normalization, empty-Bearer guard, and stale-key handling below came out of it.
- **Windows TLS trust for `https://` providers** (Anthropic/OpenAI over TLS) relies on `SSL_CERT_FILE`, since the CA-bundle probe only knows Unix paths — pre-existing, and unrelated to the Ollama (`http://`) path this PR is primarily about. Happy to follow up with Windows cert-store integration if wanted.
